### PR TITLE
プロトタイプ検索機能実装

### DIFF
--- a/src/main/java/in/tech_camp/protospace_b/config/SecurityConfig.java
+++ b/src/main/java/in/tech_camp/protospace_b/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers("/css/**", "/images/**","/uploads/**", "/", "/users/register", "/users/login","/prototypes/{id:[0-9]+}","/users/{id:[0-9]+}").permitAll()
+                        .requestMatchers("/css/**", "/images/**","/uploads/**", "/", "/users/register", "/users/login","/prototypes/{id:[0-9]+}","/users/{id:[0-9]+}","/prototypes/search").permitAll()
                         .requestMatchers(HttpMethod.POST, "/user").permitAll()
                         .anyRequest().authenticated())
                 .formLogin(login -> login

--- a/src/main/java/in/tech_camp/protospace_b/config/SecurityConfig.java
+++ b/src/main/java/in/tech_camp/protospace_b/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers("/css/**", "/images/**","/uploads/**", "/", "/users/register", "/users/login","/prototypes/{id:[0-9]+}","/users/{id:[0-9]+}","/prototypes/search").permitAll()
+                        .requestMatchers("/css/**", "/images/**","/uploads/**", "/", "/users/register", "/users/login","/prototypes/{id:[0-9]+}","/users/{id:[0-9]+}","/prototypes/search/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/user").permitAll()
                         .anyRequest().authenticated())
                 .formLogin(login -> login

--- a/src/main/java/in/tech_camp/protospace_b/controller/PrototypeController.java
+++ b/src/main/java/in/tech_camp/protospace_b/controller/PrototypeController.java
@@ -184,9 +184,10 @@ public class PrototypeController {
 
   @GetMapping("/prototypes/search")
   public String searchPrototypes(@RequestParam("keyword") String keyword, Model model) {
-  
-    List<PrototypeEntity> prototypes = prototypeRepository.findByTextContaining(keyword);
+    String KatakanaKeyword= prototypeService.convertToKatakana(keyword);
+    List<PrototypeEntity> prototypes = prototypeRepository.findByTextContaining(KatakanaKeyword);
     model.addAttribute("prototypes", prototypes);
+    model.addAttribute("keyword", keyword);
     return "prototypes/search";
   }
   

--- a/src/main/java/in/tech_camp/protospace_b/controller/PrototypeController.java
+++ b/src/main/java/in/tech_camp/protospace_b/controller/PrototypeController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import in.tech_camp.protospace_b.config.CustomUserDetails;
@@ -23,6 +24,7 @@ import in.tech_camp.protospace_b.repository.PrototypeRepository;
 import in.tech_camp.protospace_b.service.PrototypeService;
 import in.tech_camp.protospace_b.validation.ValidationOrder;
 import lombok.AllArgsConstructor;
+
 
 @Controller
 @AllArgsConstructor
@@ -168,4 +170,13 @@ public class PrototypeController {
     }
     return "redirect:/";
   }
+
+  @GetMapping("/prototypes/search")
+  public String searchPrototypes(@RequestParam("keyword") String keyword, Model model) {
+  
+    List<PrototypeEntity> prototypes = prototypeRepository.findByTextContaining(keyword);
+    model.addAttribute("prototypes", prototypes);
+    return "prototypes/search";
+  }
+  
 }

--- a/src/main/java/in/tech_camp/protospace_b/repository/CommentRepository.java
+++ b/src/main/java/in/tech_camp/protospace_b/repository/CommentRepository.java
@@ -13,7 +13,7 @@ import in.tech_camp.protospace_b.entity.CommentEntity;
 
 @Mapper
 public interface  CommentRepository {
-  @Select("SELECT c.*, u.id AS user_id, u.name AS user_name FROM comments c JOIN users u ON c.user_id = u.id WHERE c.prototype_id = #{prototypeId}")
+  @Select("SELECT c.*, u.id AS user_id, u.name AS user_name FROM comments c JOIN users u ON c.user_id = u.id WHERE c.prototype_id = #{prototypeId} ORDER BY c.created_at DESC")
   @Results(value ={
     @Result(property = "user.id", column = "user_id"),
     @Result(property = "user.name", column = "user_name"),

--- a/src/main/java/in/tech_camp/protospace_b/repository/PrototypeRepository.java
+++ b/src/main/java/in/tech_camp/protospace_b/repository/PrototypeRepository.java
@@ -17,7 +17,7 @@ import in.tech_camp.protospace_b.entity.PrototypeEntity;
 
 @Mapper
 public interface PrototypeRepository {
-  @Select("SELECT * FROM prototypes WHERE user_id = #{userId}")
+  @Select("SELECT * FROM prototypes WHERE user_id = #{userId} ORDER BY created_at DESC")
   List<PrototypeEntity> findByUserId(Integer userId);
   
   @Select("SELECT p.*, u.name AS user_name FROM prototypes p INNER JOIN users u ON p.user_id = u.id ORDER BY p.created_at DESC;")

--- a/src/main/java/in/tech_camp/protospace_b/repository/PrototypeRepository.java
+++ b/src/main/java/in/tech_camp/protospace_b/repository/PrototypeRepository.java
@@ -53,10 +53,14 @@ public interface PrototypeRepository {
           "concept=#{concept}, image=#{image} WHERE id=#{id}")
   void update(PrototypeEntity prototype);
 
-  @Select("SELECT * FROM prototypes WHERE name LIKE CONCAT('%', #{name}, '%') OR catch_copy LIKE CONCAT('%', #{text}, '%') OR concept LIKE CONCAT('%', #{text}, '%') ORDER BY created_at DESC")
+  @Select("SELECT * FROM prototypes WHERE " +
+        "translate(name, 'ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろわをん', 'ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトドナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロワヲン') ILIKE CONCAT('%', #{keyword}, '%') OR " +
+        "translate(catch_copy, 'ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろわをん', 'ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトドナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロワヲン') ILIKE CONCAT('%', #{keyword}, '%') OR " +
+        "translate(concept, 'ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろわをん', 'ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトドナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロワヲン') ILIKE CONCAT('%', #{keyword}, '%') " +
+        "ORDER BY created_at DESC")
   @Results(value = {
     @Result(property = "user", column = "user_id",
             one = @One(select = "in.tech_camp.protospace_b.repository.UserRepository.findById"))
   })
-  List<PrototypeEntity> findByTextContaining(String text);
+  List<PrototypeEntity> findByTextContaining(String keyword);
 }

--- a/src/main/java/in/tech_camp/protospace_b/repository/PrototypeRepository.java
+++ b/src/main/java/in/tech_camp/protospace_b/repository/PrototypeRepository.java
@@ -1,9 +1,8 @@
 package in.tech_camp.protospace_b.repository;
 
-import org.apache.ibatis.annotations.Delete;
-import org.apache.ibatis.annotations.Insert;
 import java.util.List;
 
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Many;
 import org.apache.ibatis.annotations.Mapper;
@@ -21,7 +20,7 @@ public interface PrototypeRepository {
   @Select("SELECT * FROM prototypes WHERE user_id = #{userId}")
   List<PrototypeEntity> findByUserId(Integer userId);
   
-  @Select("SELECT p.*, u.name AS user_name FROM prototypes p INNER JOIN users u ON p.user_id = u.id")
+  @Select("SELECT p.*, u.name AS user_name FROM prototypes p INNER JOIN users u ON p.user_id = u.id ORDER BY p.created_at DESC;")
   @Results(value = {
     @Result(property="id", column="id"),
     @Result(property="name", column="name"),
@@ -53,4 +52,11 @@ public interface PrototypeRepository {
   @Update("UPDATE prototypes SET name=#{name}, catch_copy=#{catchCopy}, " +
           "concept=#{concept}, image=#{image} WHERE id=#{id}")
   void update(PrototypeEntity prototype);
+
+  @Select("SELECT * FROM prototypes WHERE name LIKE CONCAT('%', #{name}, '%') OR catch_copy LIKE CONCAT('%', #{text}, '%') OR concept LIKE CONCAT('%', #{text}, '%') ORDER BY created_at DESC")
+  @Results(value = {
+    @Result(property = "user", column = "user_id",
+            one = @One(select = "in.tech_camp.protospace_b.repository.UserRepository.findById"))
+  })
+  List<PrototypeEntity> findByTextContaining(String text);
 }

--- a/src/main/java/in/tech_camp/protospace_b/repository/UserRepository.java
+++ b/src/main/java/in/tech_camp/protospace_b/repository/UserRepository.java
@@ -39,6 +39,7 @@ public interface UserRepository {
                 many = @Many(select = "in.tech_camp.protospace_b.repository.PrototypeRepository.findByUserId"))
     })
     UserEntity findByIdWithProto(Integer id);
-
+  
+  
 }
 

--- a/src/main/java/in/tech_camp/protospace_b/service/PrototypeService.java
+++ b/src/main/java/in/tech_camp/protospace_b/service/PrototypeService.java
@@ -128,4 +128,18 @@ public class PrototypeService {
 		return prototype;
 	}
 
+	public String convertToKatakana(String input) {
+    if (input == null) return null;
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < input.length(); i++) {
+        char c = input.charAt(i);
+        // ひらがなの範囲 (ぁ: 0x3041 〜 ん: 0x3093) をカタカナへ変換
+        if (c >= 0x3041 && c <= 0x3093) {
+            sb.append((char) (c + 0x60));
+        } else {
+            sb.append(c);
+        }
+    }
+    return sb.toString();
+}
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -104,6 +104,51 @@ header {
   color: #fff;
 }
 
+/*追加/検索フォーム*/
+.header-form{
+   flex: 1;            /* 余白を埋める設定 */
+  max-width: 400px;   /* 検索窓が広がりすぎないよう制限 */
+  margin: 0 20px;     /* 左右に余白を作る */
+}
+
+.header-form form {
+  display: flex;
+  align-items: center;
+  background-color: #fff;
+  border: 1px solid #87cefa;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 32px; 
+  
+}
+
+.search-input {
+  border: none;      
+  outline: none;    
+  background: none;  
+  padding: 4px;
+  font-size: 14px;
+  flex: 1;           
+}
+
+.search-btn {
+  background: none;      
+  border: none;          
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  color: #87cefa;        
+}
+
+.search-btn:hover {
+  opacity: 0.7;
+}
+
+.material-icons-outlined {
+  font-size: 20px;
+}
+
 /* ==========================================
    main
    ========================================== */

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -199,10 +199,12 @@ main {
   background-color: transparent; /* スペースが余った時に背景を白や透明にしたい場合 */
   display: block;
 }
+
 .prototype-index-card_body {
   height: 45%;
   margin-top: 16px;
 }
+
 .prototype-index-card_title {
   font-size: 20px;
   margin-bottom: 8px;
@@ -263,6 +265,16 @@ main {
     font-size: 12px;
   }
 }
+
+/* ==========================================
+   Search
+   ========================================== */
+.prototype-keyword{
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
 
 /* ==========================================
    Footer

--- a/src/main/resources/templates/common/head.html
+++ b/src/main/resources/templates/common/head.html
@@ -4,5 +4,6 @@
     <meta charset="UTF-8" />
     <title>protospace-b</title>
     <link rel="stylesheet" th:href="@{/css/style.css}" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet">
   </head>
 </html>

--- a/src/main/resources/templates/common/header.html
+++ b/src/main/resources/templates/common/header.html
@@ -6,6 +6,18 @@
         <div class="header-logo">
           <a th:href="@{/}"><img th:src="@{/images/Logo.png}" alt="Logo" /></a>
         </div>
+      
+        <!--検索フォーム-->
+        <div class="header-form">
+          <form th:action="@{/prototypes/search}" method="get">
+            <input type="text" name="keyword" placeholder="投稿を検索する" class="search-input">
+            <button type="submit" class="search-btn">
+               <span class="material-icons-outlined">search</span>
+            </button>
+          </form>          
+        </div>
+
+
         <div class="header-menus">
           <div class="user_nav grid-6" th:if="${#authorization.expression('isAuthenticated()')}">
             <form th:action="@{/logout}" method="post" style="display: inline-block">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -26,7 +26,7 @@
             </a>
             <div class="prototype-index-card_body">
               <a class="prototype-index-card_title" th:href="@{/prototypes/{id}(id=${prototype.id})}" th:text="${prototype.name}"></a>
-              <a class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></a>
+              <p class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></a>
               <a class="prototype-index-card_user" th:href="@{/users/{id}(id=${prototype.user.id})}" th:text="'by ' + ${prototype.user.name}"></a>
             </div>
           </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -26,7 +26,7 @@
             </a>
             <div class="prototype-index-card_body">
               <a class="prototype-index-card_title" th:href="@{/prototypes/{id}(id=${prototype.id})}" th:text="${prototype.name}"></a>
-              <p class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></a>
+              <p class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></p>
               <a class="prototype-index-card_user" th:href="@{/users/{id}(id=${prototype.user.id})}" th:text="'by ' + ${prototype.user.name}"></a>
             </div>
           </div>

--- a/src/main/resources/templates/prototypes/search.html
+++ b/src/main/resources/templates/prototypes/search.html
@@ -26,7 +26,7 @@
             </a>
             <div class="prototype-index-card_body">
               <a class="prototype-index-card_title" th:href="@{/prototypes/{id}(id=${prototype.id})}" th:text="${prototype.name}"></a>
-              <a class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></a>
+              <p class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></a>
               <a class="prototype-index-card_user" th:href="@{/users/{id}(id=${prototype.user.id})}" th:text="'by ' + ${prototype.user.name}"></a>
             </div>
           </div>

--- a/src/main/resources/templates/prototypes/search.html
+++ b/src/main/resources/templates/prototypes/search.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ja">
+  <head>
+    <th:block th:replace="~{common/head :: head}"></th:block>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+
+  <body>
+    <header th:replace="~{common/header :: header}"></header>
+    
+    <main class="prototype-index-main">
+      <div class="prototype-index-content">
+        <div class="prototype-index-greeting" th:if="${#authorization.expression('isAuthenticated()')}">
+          <span>こんにちは、</span>
+          <a 
+            class="prototype-index-greeting_link"
+            th:href="@{/users/{id}(id=${#authentication?.principal.getId()})}"
+            th:text="${#authentication?.principal.getName()} + 'さん'"
+          >
+          </a>
+        </div>
+        <div class="prototype-index-card_wrapper">
+          <div class="prototype-index-card" th:each="prototype : ${prototypes}">
+            <a th:href="@{/prototypes/{id}(id=${prototype.id})}" id="prototype_link">
+              <img class="prototype-index-card_img"  th:src="@{${prototype.image}}">
+            </a>
+            <div class="prototype-index-card_body">
+              <a class="prototype-index-card_title" th:href="@{/prototypes/{id}(id=${prototype.id})}" th:text="${prototype.name}"></a>
+              <a class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></a>
+              <a class="prototype-index-card_user" th:href="@{/users/{id}(id=${prototype.user.id})}" th:text="'by ' + ${prototype.user.name}"></a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <footer th:replace="~{common/footer :: footer}"></footer>
+  </body>
+</html>

--- a/src/main/resources/templates/prototypes/search.html
+++ b/src/main/resources/templates/prototypes/search.html
@@ -10,15 +10,7 @@
     
     <main class="prototype-index-main">
       <div class="prototype-index-content">
-        <div class="prototype-index-greeting" th:if="${#authorization.expression('isAuthenticated()')}">
-          <span>こんにちは、</span>
-          <a 
-            class="prototype-index-greeting_link"
-            th:href="@{/users/{id}(id=${#authentication?.principal.getId()})}"
-            th:text="${#authentication?.principal.getName()} + 'さん'"
-          >
-          </a>
-        </div>
+        <h3 class="prototype-keyword" th:text="|検索結果:${keyword}|"></h3>
         <div class="prototype-index-card_wrapper">
           <div class="prototype-index-card" th:each="prototype : ${prototypes}">
             <a th:href="@{/prototypes/{id}(id=${prototype.id})}" id="prototype_link">
@@ -26,7 +18,7 @@
             </a>
             <div class="prototype-index-card_body">
               <a class="prototype-index-card_title" th:href="@{/prototypes/{id}(id=${prototype.id})}" th:text="${prototype.name}"></a>
-              <p class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></a>
+              <p class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></p>
               <a class="prototype-index-card_user" th:href="@{/users/{id}(id=${prototype.user.id})}" th:text="'by ' + ${prototype.user.name}"></a>
             </div>
           </div>

--- a/src/test/java/in/tech_camp/protospace_b/controller/PrototypeControllerUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_b/controller/PrototypeControllerUnitTest.java
@@ -416,6 +416,7 @@ public class PrototypeControllerUnitTest {
       // テストデータをexpectedPrototypeListに格納
       List<PrototypeEntity> expectedPrototypeList = Arrays.asList(prototype1, prototype2, prototype3);
 
+      when(prototypeService.convertToKatakana("プロトタイプ")).thenReturn("プロトタイプ");
       // findAllメソッド呼び出し時expectedPrototypeListを返す
       when(prototypeRepository.findByTextContaining("プロトタイプ")).thenReturn(expectedPrototypeList);
 

--- a/src/test/java/in/tech_camp/protospace_b/controller/PrototypeControllerUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_b/controller/PrototypeControllerUnitTest.java
@@ -396,4 +396,37 @@ public class PrototypeControllerUnitTest {
     assertThat(result, is("redirect:/prototypes/1"));
     }
   }
+
+  @Nested
+  class プロトタイプ検索機能{
+    @Test
+    public void 検索キーワードを入力すると対象のプロトタイプが表示されるか(){
+      PrototypeEntity prototype1 = new PrototypeEntity();
+      prototype1.setId(1);
+      prototype1.setName("プロトタイプな名前");
+
+      PrototypeEntity prototype2 = new PrototypeEntity();
+      prototype2.setId(2);
+      prototype2.setCatchCopy("これはプロトタイプです");
+
+      PrototypeEntity prototype3 = new PrototypeEntity();
+      prototype3.setId(3);
+      prototype3.setConcept("プロトタイプという概念");
+
+      // テストデータをexpectedPrototypeListに格納
+      List<PrototypeEntity> expectedPrototypeList = Arrays.asList(prototype1, prototype2, prototype3);
+
+      // findAllメソッド呼び出し時expectedPrototypeListを返す
+      when(prototypeRepository.findByTextContaining("プロトタイプ")).thenReturn(expectedPrototypeList);
+
+      // テスト用のモデルオブジェクトを生成し、showPrototypesに渡す
+      String result= prototypeController.searchPrototypes("プロトタイプ", model);
+
+      //　対象のビューが表示されるか
+      assertThat(result, is("prototypes/search"));
+
+      // 実測値prototypesが期待値expectedPrototypeListと一致するか確認
+      assertThat(model.getAttribute("prototypes"), is(expectedPrototypeList));
+    }
+  }
 }


### PR DESCRIPTION
# What
プロトタイプ検索機能の追加

# Why
プロトタイプの検索ができるようにするため

## 対応チケット
#52 

## 実装内容
### 機能
- プロトタイプ検索　**GET：/prototypes/search**

- ヘッダーに検索フォームを追加
 
- 部分一致でプロトタイプを検索
- (name, catch_copy, conceptのどれかに引っかかるように実装)

- 検索結果は、投稿一覧と同じUIの検索結果ページを用意

- 結果一覧はcreated_atの降順に指定
- 投稿一覧とユーザー詳細のプロトタイプ一覧とコメント一覧も降順に表示されるように実装）

---
### 単体テスト
・PrototypeControllerUnitTest
　・検索キーワードを入力すると対象のプロトタイプが表示されるか