### PR TITLE
追加実装/いいね機能

### DIFF
--- a/src/main/java/in/tech_camp/protospace_b/config/SecurityConfig.java
+++ b/src/main/java/in/tech_camp/protospace_b/config/SecurityConfig.java
@@ -20,6 +20,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                         .requestMatchers("/css/**", "/images/**","/uploads/**", "/", "/users/register", "/users/login","/prototypes/{id:[0-9]+}","/users/{id:[0-9]+}").permitAll()
                         .requestMatchers(HttpMethod.POST, "/user").permitAll()
+                        .requestMatchers("/api/**").authenticated()
                         .anyRequest().authenticated())
                 .formLogin(login -> login
                         .loginProcessingUrl("/login")

--- a/src/main/java/in/tech_camp/protospace_b/controller/LikeController.java
+++ b/src/main/java/in/tech_camp/protospace_b/controller/LikeController.java
@@ -1,0 +1,29 @@
+package in.tech_camp.protospace_b.controller;
+
+import java.util.Map;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.tech_camp.protospace_b.config.CustomUserDetails;
+import in.tech_camp.protospace_b.service.LikeService;
+import lombok.RequiredArgsConstructor;
+
+
+@RestController
+@RequiredArgsConstructor
+public class LikeController {
+  private final LikeService likeService;
+
+  @PostMapping("/api/prototypes/{id}/like")
+  public Map<String, Object> toggleLike(@PathVariable("id") Integer prototypeId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    if (userDetails == null) {
+        throw new RuntimeException("ログインしてください");
+    }
+
+    Integer userId = userDetails.getId();
+    return likeService.toggleLike(userId, prototypeId);
+  }
+}

--- a/src/main/java/in/tech_camp/protospace_b/controller/PrototypeController.java
+++ b/src/main/java/in/tech_camp/protospace_b/controller/PrototypeController.java
@@ -172,11 +172,29 @@ public class PrototypeController {
   
   //プロトタイプ詳細画面への遷移
   @GetMapping("/prototypes/{prototypeId}")
-  public String showPrototypeDetail(@PathVariable("prototypeId") Integer prototypeId, Model model) {
+  public String showPrototypeDetail(@PathVariable("prototypeId") Integer prototypeId, Model model, Authentication authentication) {
       PrototypeEntity prototype = prototypeRepository.findById(prototypeId);
       if(prototype == null){
         return "redirect:/";
       }
+
+    Integer currentUserId = null;
+    if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails) {
+        currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getId();
+    }
+
+    // ★ 2. この「1つのprototype」に対していいね情報を直接セットする
+    // いいね総数をセット
+    prototype.setLikeCount(likeRepository.countByPrototypeId(prototype.getId()));
+    
+    // 自分がいいね済みかチェック
+    if (currentUserId != null) {
+        int likeCheck = likeRepository.countByUserAndPrototype(currentUserId, prototype.getId());
+        prototype.setIsLiked(likeCheck > 0);
+    } else {
+        prototype.setIsLiked(false);
+    }
+
       model.addAttribute("prototype", prototype);
       model.addAttribute("commentForm", new CommentForm());
       model.addAttribute("comments",prototype.getComments());
@@ -206,9 +224,30 @@ public class PrototypeController {
   }
 
   @GetMapping("/prototypes/search")
-  public String searchPrototypes(@RequestParam("keyword") String keyword, Model model) {
+  public String searchPrototypes(@RequestParam("keyword") String keyword, Model model, Authentication authentication) {
     String KatakanaKeyword= prototypeService.convertToKatakana(keyword);
     List<PrototypeEntity> prototypes = prototypeRepository.findByTextContaining(KatakanaKeyword);
+
+    // ログイン中のユーザーIDを取得（未ログインならnull）
+    Integer currentUserId = null;
+    if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails) {
+        currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getId();
+    }
+
+    // 検索結果の各プロトタイプに「いいね」情報をセット
+    for (PrototypeEntity prototype : prototypes) {
+        // いいね総数をセット
+        prototype.setLikeCount(likeRepository.countByPrototypeId(prototype.getId()));
+        
+        // 自分がいいね済みかチェック
+        if (currentUserId != null) {
+            int likeCheck = likeRepository.countByUserAndPrototype(currentUserId, prototype.getId());
+            prototype.setIsLiked(likeCheck > 0);
+        } else {
+            prototype.setIsLiked(false);
+        }
+    }
+
     model.addAttribute("prototypes", prototypes);
     model.addAttribute("keyword", keyword);
     return "prototypes/search";

--- a/src/main/java/in/tech_camp/protospace_b/entity/LikeEntity.java
+++ b/src/main/java/in/tech_camp/protospace_b/entity/LikeEntity.java
@@ -1,0 +1,13 @@
+package in.tech_camp.protospace_b.entity;
+
+import java.sql.Timestamp;
+
+import lombok.Data;
+
+@Data
+public class LikeEntity {
+  private Integer id;
+  private Integer userId;
+  private Integer prototypeId;
+  private Timestamp createdAt;
+} 

--- a/src/main/java/in/tech_camp/protospace_b/entity/PrototypeEntity.java
+++ b/src/main/java/in/tech_camp/protospace_b/entity/PrototypeEntity.java
@@ -15,4 +15,6 @@ public class PrototypeEntity {
   private Timestamp createdAt;
   private UserEntity user;
   private List<CommentEntity> comments;
+  private Integer LikeCount;
+  private Boolean isLiked;
 }

--- a/src/main/java/in/tech_camp/protospace_b/repository/LikeRepository.java
+++ b/src/main/java/in/tech_camp/protospace_b/repository/LikeRepository.java
@@ -1,0 +1,26 @@
+package in.tech_camp.protospace_b.repository;
+
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface LikeRepository {
+  // いいね追加
+  @Insert("INSERT into likes (user_id, prototype_id) VALUES(#{userId}, #{prototypeId})")
+  void insert(@Param("userId") Integer userId, @Param("prototypeId") Integer prototypeId);
+
+  // いいね削除
+  @Delete("DELETE FROM likes WHERE user_id = #{userId} AND prototype_id = #{prototypeId}")
+  void delete(@Param("userId") Integer userId, @Param("prototypeId") Integer prototypeId);
+
+  // 投稿のいいね数を取得
+  @Select("SELECT COUNT(*) FROM likes WHERE prototype_id =#{prototypeId}")
+  int countByPrototypeId(@Param("prototypeId") Integer prototypeId);
+
+  // 既にいいね済みかどうか確認
+  @Select("SELECT COUNT(*) FROM likes WHERE user_id = #{userId} AND prototype_id = #{prototypeId}")
+  int countByUserAndPrototype(@Param("userId") Integer userId, @Param("prototypeId") Integer prototypeId);
+}

--- a/src/main/java/in/tech_camp/protospace_b/service/LikeService.java
+++ b/src/main/java/in/tech_camp/protospace_b/service/LikeService.java
@@ -1,0 +1,38 @@
+package in.tech_camp.protospace_b.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.tech_camp.protospace_b.repository.LikeRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+  private final LikeRepository likeRepository;
+
+  @Transactional
+  public Map<String, Object> toggleLike(Integer userId, Integer prototypeId) {
+    int count = likeRepository.countByUserAndPrototype(userId, prototypeId);
+    boolean isLiked;
+
+    if (count > 0) {
+      likeRepository.delete(userId, prototypeId);
+      isLiked = false;
+    } else {
+      likeRepository.insert(userId, prototypeId);
+      isLiked = true;
+    }
+
+    int totalLikes = likeRepository.countByPrototypeId(prototypeId);
+
+    Map<String, Object> result = new HashMap<>();
+    result.put("isLiked", isLiked);
+    result.put("LikeCount", totalLikes);
+    
+    return result;
+  }
+}

--- a/src/main/resources/db/migration/V4__create_likes_table.sql
+++ b/src/main/resources/db/migration/V4__create_likes_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE likes (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    prototype_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    
+    UNIQUE (user_id, prototype_id),
+    
+    CONSTRAINT fk_likes_user_id FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    CONSTRAINT fk_likes_prototype_id FOREIGN KEY (prototype_id) REFERENCES prototypes (id) ON DELETE CASCADE
+);

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -105,10 +105,10 @@ header {
 }
 
 /*追加/検索フォーム*/
-.header-form{
-   flex: 1;            /* 余白を埋める設定 */
-  max-width: 400px;   /* 検索窓が広がりすぎないよう制限 */
-  margin: 0 20px;     /* 左右に余白を作る */
+.header-form {
+  flex: 1; /* 余白を埋める設定 */
+  max-width: 400px; /* 検索窓が広がりすぎないよう制限 */
+  margin: 0 20px; /* 左右に余白を作る */
 }
 
 .header-form form {
@@ -118,27 +118,26 @@ header {
   border: 1px solid #87cefa;
   border-radius: 4px;
   padding: 0 8px;
-  height: 32px; 
-  
+  height: 32px;
 }
 
 .search-input {
-  border: none;      
-  outline: none;    
-  background: none;  
+  border: none;
+  outline: none;
+  background: none;
   padding: 4px;
   font-size: 14px;
-  flex: 1;           
+  flex: 1;
 }
 
 .search-btn {
-  background: none;      
-  border: none;          
+  background: none;
+  border: none;
   padding: 0;
   cursor: pointer;
   display: flex;
   align-items: center;
-  color: #87cefa;        
+  color: #87cefa;
 }
 
 .search-btn:hover {
@@ -226,6 +225,14 @@ main {
   line-height: 25px;
   margin-bottom: 8px;
 }
+
+.prototype-index-user-and-like {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
 .prototype-index-card_user {
   display: block;
   font-size: 12px;
@@ -269,12 +276,11 @@ main {
 /* ==========================================
    Search
    ========================================== */
-.prototype-keyword{
+.prototype-keyword {
   font-size: 20px;
   font-weight: 700;
   margin-bottom: 10px;
 }
-
 
 /* ==========================================
    Footer
@@ -395,6 +401,13 @@ footer {
   font-size: 24px;
   line-height: 100%;
   color: #3b4043;
+}
+
+.prototype-show-user-and-like {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
 }
 
 .prototype-show-author {

--- a/src/main/resources/static/js/like.js
+++ b/src/main/resources/static/js/like.js
@@ -1,0 +1,40 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const likeButtons = document.querySelectorAll(".like-btn");
+
+  likeButtons.forEach((button) => {
+    button.addEventListener("click", async () => {
+      const prototypeId = button.getAttribute("data-prototype-id");
+      const icon = button.querySelector(".like-icon");
+      const countSpan = button.querySelector(".like-count");
+
+      try {
+        const response = await fetch(`/api/prototypes/${prototypeId}/like`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error("いいねの処理に失敗しました");
+        }
+
+        const data = await response.json();
+
+        // 表示の更新
+        countSpan.innerText = data.LikeCount;
+
+        if (data.isLiked) {
+          icon.style.fontVariationSettings = "'FILL' 1";
+          icon.style.color = "#e0245e";
+        } else {
+          icon.style.fontVariationSettings = "'FILL' 0";
+          icon.style.color = "#657786";
+        }
+      } catch (error) {
+        console.error("Error:", error);
+        alert("エラーが発生しました。ログイン状態を確認してください。");
+      }
+    });
+  });
+});

--- a/src/main/resources/templates/common/head.html
+++ b/src/main/resources/templates/common/head.html
@@ -8,6 +8,10 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"
+      rel="stylesheet"
+    />
+    <script th:src="@{/js/like.js}" defer></script>
   </head>
 </html>

--- a/src/main/resources/templates/common/head.html
+++ b/src/main/resources/templates/common/head.html
@@ -1,8 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
   <head th:fragment="head">
     <meta charset="UTF-8" />
     <title>protospace-b</title>
     <link rel="stylesheet" th:href="@{/css/style.css}" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+    />
   </head>
 </html>

--- a/src/main/resources/templates/common/like.html
+++ b/src/main/resources/templates/common/like.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <body>
+    <div th:fragment="like">
+      <div
+        class="like-container"
+        th:if="${#authorization.expression('isAuthenticated()')}"
+      >
+        <button
+          type="button"
+          class="like-btn"
+          th:data-prototype-id="${prototype.id}"
+          style="
+            border: none;
+            background: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            padding: 0;
+          "
+        >
+          <span
+            class="material-symbols-outlined like-icon"
+            th:data-is-liked="${prototype.isLiked}"
+            th:style="${prototype.isLiked == true} ? 'font-variation-settings: \'FILL\' 1; color: #e0245e; font-size: 20px;' : 'font-variation-settings: \'FILL\' 0; color: #657786; font-size: 20px;'"
+          >
+            favorite
+          </span>
+          <span
+            class="like-count"
+            style="margin-left: 4px; color: #657786; font-size: 14px"
+            th:text="${prototype.likeCount}"
+            >0</span
+          >
+        </button>
+      </div>
+
+      <div
+        class="like-container"
+        th:unless="${#authorization.expression('isAuthenticated()')}"
+        style="display: flex; align-items: center"
+      >
+        <span
+          class="material-symbols-outlined like-icon"
+          th:data-is-liked="${prototype.isLiked}"
+          th:style="${prototype.isLiked == true} ? 'font-variation-settings: \'FILL\' 1; color: #e0245e; font-size: 20px;' : 'font-variation-settings: \'FILL\' 0; color: #657786; font-size: 20px;'"
+        >
+          favorite</span
+        >
+        <span
+          style="margin-left: 4px; color: #657786; font-size: 14px"
+          th:text="${prototype.likeCount}"
+          >0</span
+        >
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ja">
   <head>
     <th:block th:replace="~{common/head :: head}"></th:block>
@@ -7,12 +7,15 @@
 
   <body>
     <header th:replace="~{common/header :: header}"></header>
-    
+
     <main class="prototype-index-main">
       <div class="prototype-index-content">
-        <div class="prototype-index-greeting" th:if="${#authorization.expression('isAuthenticated()')}">
+        <div
+          class="prototype-index-greeting"
+          th:if="${#authorization.expression('isAuthenticated()')}"
+        >
           <span>こんにちは、</span>
-          <a 
+          <a
             class="prototype-index-greeting_link"
             th:href="@{/users/{id}(id=${#authentication?.principal.getId()})}"
             th:text="${#authentication?.principal.getName()} + 'さん'"
@@ -21,13 +24,81 @@
         </div>
         <div class="prototype-index-card_wrapper">
           <div class="prototype-index-card" th:each="prototype : ${prototypes}">
-            <a th:href="@{/prototypes/{id}(id=${prototype.id})}" id="prototype_link">
-              <img class="prototype-index-card_img"  th:src="@{${prototype.image}}">
+            <a
+              th:href="@{/prototypes/{id}(id=${prototype.id})}"
+              id="prototype_link"
+            >
+              <img
+                class="prototype-index-card_img"
+                th:src="@{${prototype.image}}"
+              />
             </a>
             <div class="prototype-index-card_body">
-              <a class="prototype-index-card_title" th:href="@{/prototypes/{id}(id=${prototype.id})}" th:text="${prototype.name}"></a>
-              <a class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></a>
-              <a class="prototype-index-card_user" th:href="@{/users/{id}(id=${prototype.user.id})}" th:text="'by ' + ${prototype.user.name}"></a>
+              <a
+                class="prototype-index-card_title"
+                th:href="@{/prototypes/{id}(id=${prototype.id})}"
+                th:text="${prototype.name}"
+              ></a>
+              <a
+                class="prototype-index-card_summary"
+                th:text="${prototype.catchCopy}"
+              ></a>
+              <a
+                class="prototype-index-card_user"
+                th:href="@{/users/{id}(id=${prototype.user.id})}"
+                th:text="'by ' + ${prototype.user.name}"
+              ></a>
+              <div
+                class="like-container"
+                th:if="${#authorization.expression('isAuthenticated()')}"
+              >
+                <button
+                  type="button"
+                  class="like-btn"
+                  th:data-prototype-id="${prototype.id}"
+                  style="
+                    border: none;
+                    background: none;
+                    cursor: pointer;
+                    display: flex;
+                    align-items: center;
+                    padding: 0;
+                  "
+                >
+                  <span
+                    class="material-symbols-outlined like-icon"
+                    th:data-is-liked="${prototype.isLiked}"
+                    th:style="${prototype.isLiked == true} ? 'font-variation-settings: \'FILL\' 1; color: #e0245e; font-size: 20px;' : 'font-variation-settings: \'FILL\' 0; color: #657786; font-size: 20px;'"
+                  >
+                    favorite
+                  </span>
+                  <span
+                    class="like-count"
+                    style="margin-left: 4px; color: #657786; font-size: 14px"
+                    th:text="${prototype.likeCount}"
+                    >0</span
+                  >
+                </button>
+              </div>
+
+              <div
+                class="like-container"
+                th:unless="${#authorization.expression('isAuthenticated()')}"
+                style="display: flex; align-items: center"
+              >
+                <span
+                  class="material-symbols-outlined like-icon"
+                  th:data-is-liked="${prototype.isLiked}"
+                  th:style="${prototype.isLiked == true} ? 'font-variation-settings: \'FILL\' 1; color: #e0245e; font-size: 20px;' : 'font-variation-settings: \'FILL\' 0; color: #657786; font-size: 20px;'"
+                >
+                  favorite</span
+                >
+                <span
+                  style="margin-left: 4px; color: #657786; font-size: 14px"
+                  th:text="${prototype.likeCount}"
+                  >0</span
+                >
+              </div>
             </div>
           </div>
         </div>
@@ -35,5 +106,6 @@
     </main>
 
     <footer th:replace="~{common/footer :: footer}"></footer>
+    <script th:src="@{/js/like.js}"></script>
   </body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -43,61 +43,13 @@
                 class="prototype-index-card_summary"
                 th:text="${prototype.catchCopy}"
               ></a>
-              <a
-                class="prototype-index-card_user"
-                th:href="@{/users/{id}(id=${prototype.user.id})}"
-                th:text="'by ' + ${prototype.user.name}"
-              ></a>
-              <div
-                class="like-container"
-                th:if="${#authorization.expression('isAuthenticated()')}"
-              >
-                <button
-                  type="button"
-                  class="like-btn"
-                  th:data-prototype-id="${prototype.id}"
-                  style="
-                    border: none;
-                    background: none;
-                    cursor: pointer;
-                    display: flex;
-                    align-items: center;
-                    padding: 0;
-                  "
-                >
-                  <span
-                    class="material-symbols-outlined like-icon"
-                    th:data-is-liked="${prototype.isLiked}"
-                    th:style="${prototype.isLiked == true} ? 'font-variation-settings: \'FILL\' 1; color: #e0245e; font-size: 20px;' : 'font-variation-settings: \'FILL\' 0; color: #657786; font-size: 20px;'"
-                  >
-                    favorite
-                  </span>
-                  <span
-                    class="like-count"
-                    style="margin-left: 4px; color: #657786; font-size: 14px"
-                    th:text="${prototype.likeCount}"
-                    >0</span
-                  >
-                </button>
-              </div>
-
-              <div
-                class="like-container"
-                th:unless="${#authorization.expression('isAuthenticated()')}"
-                style="display: flex; align-items: center"
-              >
-                <span
-                  class="material-symbols-outlined like-icon"
-                  th:data-is-liked="${prototype.isLiked}"
-                  th:style="${prototype.isLiked == true} ? 'font-variation-settings: \'FILL\' 1; color: #e0245e; font-size: 20px;' : 'font-variation-settings: \'FILL\' 0; color: #657786; font-size: 20px;'"
-                >
-                  favorite</span
-                >
-                <span
-                  style="margin-left: 4px; color: #657786; font-size: 14px"
-                  th:text="${prototype.likeCount}"
-                  >0</span
-                >
+              <div class="prototype-index-user-and-like">
+                <div th:replace="~{common/like :: like}"></div>
+                <a
+                  class="prototype-index-card_user"
+                  th:href="@{/users/{id}(id=${prototype.user.id})}"
+                  th:text="'by ' + ${prototype.user.name}"
+                ></a>
               </div>
             </div>
           </div>
@@ -106,6 +58,5 @@
     </main>
 
     <footer th:replace="~{common/footer :: footer}"></footer>
-    <script th:src="@{/js/like.js}"></script>
   </body>
 </html>

--- a/src/main/resources/templates/prototypes/search.html
+++ b/src/main/resources/templates/prototypes/search.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ja">
   <head>
     <th:block th:replace="~{common/head :: head}"></th:block>
@@ -7,19 +7,30 @@
 
   <body>
     <header th:replace="~{common/header :: header}"></header>
-    
+
     <main class="prototype-index-main">
       <div class="prototype-index-content">
         <h3 class="prototype-keyword" th:text="|検索結果:${keyword}|"></h3>
         <div class="prototype-index-card_wrapper">
           <div class="prototype-index-card" th:each="prototype : ${prototypes}">
-            <a th:href="@{/prototypes/{id}(id=${prototype.id})}" id="prototype_link">
-              <img class="prototype-index-card_img"  th:src="@{${prototype.image}}">
+            <a
+              th:href="@{/prototypes/{id}(id=${prototype.id})}"
+              id="prototype_link"
+            >
+              <img
+                class="prototype-index-card_img"
+                th:src="@{${prototype.image}}"
+              />
             </a>
             <div class="prototype-index-card_body">
-              <a class="prototype-index-card_title" th:href="@{/prototypes/{id}(id=${prototype.id})}" th:text="${prototype.name}"></a>
-              <p class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></p>
-              <a class="prototype-index-card_user" th:href="@{/users/{id}(id=${prototype.user.id})}" th:text="'by ' + ${prototype.user.name}"></a>
+              <div class="prototype-index-user-and-like">
+                <div th:replace="~{common/like :: like}"></div>
+                <a
+                  class="prototype-index-card_user"
+                  th:href="@{/users/{id}(id=${prototype.user.id})}"
+                  th:text="'by ' + ${prototype.user.name}"
+                ></a>
+              </div>
             </div>
           </div>
         </div>

--- a/src/main/resources/templates/prototypes/show.html
+++ b/src/main/resources/templates/prototypes/show.html
@@ -11,20 +11,34 @@
       <div class="prototype-show-container">
         <div class="prototype-show-header">
           <h3 class="title-h2" th:text="${prototype.name}"></h3>
-          <a
-            th:href="@{/users/{id}(id=${prototype.user.id})}"
-            class="prototype-show-author"
-            th:text="'by ' + ${prototype.user.name}"
-          ></a>
+          <div class="prototype-show-user-and-like">
+            <div th:replace="~{common/like :: like}"></div>
+            <a
+              th:href="@{/users/{id}(id=${prototype.user.id})}"
+              class="prototype-show-author"
+              th:text="'by ' + ${prototype.user.name}"
+            ></a>
+          </div>
 
           <!--ログイン状態かつ自分の投稿かでボタンの表示変更-->
           <div
             th:if="${#authorization.expression('isAuthenticated()') and #authentication.principal.getId == prototype.user.id}"
           >
             <div class="prototype-show-button-section">
-              <a th:href="@{/prototypes/{id}/edit(id=${prototype.id})}" class="prototype-show-btn">編集する</a>
-              <form th:action="@{/prototypes/{prototypeId}/delete(prototypeId=${prototype.id})}" th:method="post">
-                <input type="submit" class="prototype-show-btn" value="削除する" />
+              <a
+                th:href="@{/prototypes/{id}/edit(id=${prototype.id})}"
+                class="prototype-show-btn"
+                >編集する</a
+              >
+              <form
+                th:action="@{/prototypes/{prototypeId}/delete(prototypeId=${prototype.id})}"
+                th:method="post"
+              >
+                <input
+                  type="submit"
+                  class="prototype-show-btn"
+                  value="削除する"
+                />
               </form>
             </div>
           </div>
@@ -38,17 +52,27 @@
       <div class="prototype-show-description">
         <div class="prototype-show-info-group">
           <h3 class="prototype-show-info-label">キャッチコピー</h3>
-          <p class="prototype-show-info-text" th:text="${prototype.catchCopy}"></p>
+          <p
+            class="prototype-show-info-text"
+            th:text="${prototype.catchCopy}"
+          ></p>
         </div>
         <div class="prototype-show-info-group">
           <h3 class="prototype-show-info-label">コンセプト</h3>
-          <p class="prototype-show-info-text" th:text="${prototype.concept}"></p>
+          <p
+            class="prototype-show-info-text"
+            th:text="${prototype.concept}"
+          ></p>
         </div>
 
         <!--コメントエリア-->
         <div class="prototype-show-comment-section">
           <div th:if="${#authorization.expression('isAuthenticated()')}">
-            <div th:if="${errorMessages}" th:each="error : ${errorMessages}" class="new-error">
+            <div
+              th:if="${errorMessages}"
+              th:each="error : ${errorMessages}"
+              class="new-error"
+            >
               <div th:text="${error.defaultMessage}"></div>
             </div>
             <form
@@ -57,8 +81,15 @@
               th:object="${commentForm}"
               class="prototype-show-comment-form"
             >
-              <label for="comment" class="prototype-show-comment-label">コメント</label>
-              <input class="prototype-show-comment-input" th:field="*{text}" type="text" id="comment" />
+              <label for="comment" class="prototype-show-comment-label"
+                >コメント</label
+              >
+              <input
+                class="prototype-show-comment-input"
+                th:field="*{text}"
+                type="text"
+                id="comment"
+              />
               <input class="com-btn" type="submit" value="送信する" />
             </form>
           </div>
@@ -70,7 +101,10 @@
 
           <ul class="prototype-show-comments">
             <li th:each="comment:${comments}" class="prototype-show-comment">
-              <span class="prototype-show-comment-text" th:text="${comment.text}"></span>
+              <span
+                class="prototype-show-comment-text"
+                th:text="${comment.text}"
+              ></span>
               <a
                 th:href="@{/users/{userId}(userId=${comment.user.id})}"
                 th:text="${comment.user.name}"

--- a/src/main/resources/templates/users/show.html
+++ b/src/main/resources/templates/users/show.html
@@ -8,7 +8,9 @@
     <header th:replace="~{common/header :: header}"></header>
     <main class="user-show-container">
       <section class="user-show-info">
-        <h2 class="user-show-h2" th:text="${user.name} + 'さんの情報'">名前さんの情報</h2>
+        <h2 class="user-show-h2" th:text="${user.name} + 'さんの情報'">
+          名前さんの情報
+        </h2>
         <!-- ユーザーデータテーブル -->
         <table class="user-show-info-table">
           <tr>
@@ -34,7 +36,10 @@
       </section>
 
       <section class="user-show-prototype-section">
-        <h2 class="user-show-prototype-name" th:text="${user.name} + 'さんのプロトタイプ'">
+        <h2
+          class="user-show-prototype-name"
+          th:text="${user.name} + 'さんのプロトタイプ'"
+        >
           名前さんのプロトタイプ
         </h2>
         <!-- ユーザー個人のPrototype一覧 -->
@@ -44,21 +49,33 @@
             <a
               id="prototype_link"
               th:href="@{/prototypes/{prototypeId}(prototypeId=${prototype.id})}"
-              ><img class="prototype-index-card_img" th:src="@{${prototype.image}}" alt="img"
+              ><img
+                class="prototype-index-card_img"
+                th:src="@{${prototype.image}}"
+                alt="img"
             /></a>
 
             <div class="prototype-index-card_body">
-              <h3 th:text="${prototype.name}" class="prototype-index-card_title">
+              <h3
+                th:text="${prototype.name}"
+                class="prototype-index-card_title"
+              >
                 プロトタイプタイトル
               </h3>
-              <p class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></p>
+              <p
+                class="prototype-index-card_summary"
+                th:text="${prototype.catchCopy}"
+              ></p>
+              <div class="prototype-index-user-and-like">
+                <div th:replace="~{common/like :: like}"></div>
 
-              <a
-                th:href="@{/users/{id}(id=${user.id})}"
-                th:text="|by ${user.name}|"
-                class="prototype-index-card_user"
-                >by 名前</a
-              >
+                <a
+                  th:href="@{/users/{id}(id=${user.id})}"
+                  th:text="|by ${user.name}|"
+                  class="prototype-index-card_user"
+                  >by 名前</a
+                >
+              </div>
             </div>
           </div>
         </div>

--- a/src/test/java/in/tech_camp/protospace_b/controller/LikeControllerUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_b/controller/LikeControllerUnitTest.java
@@ -1,0 +1,77 @@
+package in.tech_camp.protospace_b.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import in.tech_camp.protospace_b.config.CustomUserDetails;
+import in.tech_camp.protospace_b.entity.UserEntity;
+import in.tech_camp.protospace_b.service.LikeService;
+
+@WebMvcTest(LikeController.class)
+@ActiveProfiles("test")
+public class LikeControllerUnitTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private LikeService likeService;
+
+  @Nested
+    class ログイン済みの場合 {
+
+    @Test
+    public void いいねボタンを押すと200OKとJSONが返ること() throws Exception {
+      Map<String, Object> mockResult = new HashMap<>();
+      mockResult.put("isLiked", true);
+      mockResult.put("LikeCount", 5);
+
+      when(likeService.toggleLike(anyInt(), anyInt())).thenReturn(mockResult);
+
+      UserEntity user = new UserEntity();
+      user.setId(1);
+      CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+
+      mockMvc.perform(post("/api/prototypes/10/like")
+              .with(SecurityMockMvcRequestPostProcessors.user(customUserDetails)) // ログイン状態を再現
+              .with(SecurityMockMvcRequestPostProcessors.csrf()))
+              .andExpect(status().isOk())
+              .andExpect(jsonPath("$.isLiked").value(true))
+              .andExpect(jsonPath("$.LikeCount").value(5));
+      
+      verify(likeService, times(1)).toggleLike(eq(1), eq(10));
+    }
+  }
+
+  @Nested
+  class 未ログインの場合 {
+    @Test
+    public void いいねボタンを押すとエラーが発生すること() throws Exception {
+      // ログイン情報を渡さずにPOSTリクエスト
+      mockMvc.perform(post("/api/prototypes/10/like")
+              .with(SecurityMockMvcRequestPostProcessors.csrf()))
+              .andExpect(status().isUnauthorized());
+      
+      // Serviceは呼ばれていないことを検証
+      verify(likeService, never()).toggleLike(anyInt(), anyInt());
+    }
+  }
+}

--- a/src/test/java/in/tech_camp/protospace_b/controller/PrototypeControllerUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_b/controller/PrototypeControllerUnitTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.InjectMocks;
@@ -50,6 +51,9 @@ public class PrototypeControllerUnitTest {
   private PrototypeService prototypeService;  
 
   @Mock
+  private in.tech_camp.protospace_b.repository.LikeRepository likeRepository;
+
+  @Mock
   private BindingResult bindingResult;
 
   @Mock
@@ -82,7 +86,7 @@ public class PrototypeControllerUnitTest {
     
     @Test
     public void プロトタイプ一覧にリクエストするとプロトタイプ一覧のビューファイルがレスポンスで返ってくる(){
-      String result = prototypeController.showPrototypes(model);
+      String result = prototypeController.showPrototypes(model, authentication);
       assertThat(result,is("index"));
     }
 
@@ -108,8 +112,14 @@ public class PrototypeControllerUnitTest {
       // findAllメソッド呼び出し時expectedPrototypeListを返す
       when(prototypeRepository.findAll()).thenReturn(expectedPrototypeList);
 
+      // いいねカウントのモック設定
+      when(likeRepository.countByPrototypeId(anyInt())).thenReturn(5);
+      
+      // ログイン中ユーザーのいいねチェック (0 = 未いいねとして返す)
+      when(likeRepository.countByUserAndPrototype(any(), anyInt())).thenReturn(0);
+
       // テスト用のモデルオブジェクトを生成し、showPrototypesに渡す
-      prototypeController.showPrototypes(model);
+      prototypeController.showPrototypes(model, authentication);
 
       // 実測値prototypesが期待値expectedPrototypeListと一致するか確認
       assertThat(model.getAttribute("prototypes"), is(expectedPrototypeList));

--- a/src/test/java/in/tech_camp/protospace_b/controller/PrototypeControllerUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_b/controller/PrototypeControllerUnitTest.java
@@ -136,7 +136,7 @@ public class PrototypeControllerUnitTest {
       prototype.setId(prototypeId);
 
       when(prototypeRepository.findById(1)).thenReturn(prototype);
-      String result = prototypeController.showPrototypeDetail(1, model);
+      String result = prototypeController.showPrototypeDetail(1, model, authentication);
 
       assertThat(result, is("prototypes/show"));
     }
@@ -148,7 +148,7 @@ public class PrototypeControllerUnitTest {
       prototype.setId(prototypeId);
 
       when(prototypeRepository.findById(1)).thenReturn(prototype);
-      String result = prototypeController.showPrototypeDetail(1, model);
+      String result = prototypeController.showPrototypeDetail(1, model, authentication);
 
       assertThat(result, is("prototypes/show"));
 
@@ -158,7 +158,7 @@ public class PrototypeControllerUnitTest {
     @Test
     public void 詳細機能にリクエストするときにDBに無いプロトタイプIDを指定されたときにトップページにリダイレクトされる(){
       when(prototypeRepository.findById(1)).thenReturn(null);
-      String result = prototypeController.showPrototypeDetail(1, model);
+      String result = prototypeController.showPrototypeDetail(1, model, authentication);
       assertThat(result, is("redirect:/"));
     }
 
@@ -169,7 +169,7 @@ public class PrototypeControllerUnitTest {
       PrototypeEntity prototype = new PrototypeEntity();
       prototype.setId(1);
       when(prototypeRepository.findById(1)).thenReturn(prototype);
-      prototypeController.showPrototypeDetail(1, model);
+      prototypeController.showPrototypeDetail(1, model, authentication);
       assertThat(model.getAttribute("commentForm"), is(commentForm));
     }
 
@@ -190,7 +190,7 @@ public class PrototypeControllerUnitTest {
       prototype.setComments(expectedCommentList);
 
       when(prototypeRepository.findById(1)).thenReturn(prototype);
-      prototypeController.showPrototypeDetail(1, model);
+      prototypeController.showPrototypeDetail(1, model, authentication);
       assertThat(model.getAttribute("comments"), is(expectedCommentList));
     }
   }
@@ -431,7 +431,7 @@ public class PrototypeControllerUnitTest {
       when(prototypeRepository.findByTextContaining("プロトタイプ")).thenReturn(expectedPrototypeList);
 
       // テスト用のモデルオブジェクトを生成し、showPrototypesに渡す
-      String result= prototypeController.searchPrototypes("プロトタイプ", model);
+      String result= prototypeController.searchPrototypes("プロトタイプ", model, authentication);
 
       //　対象のビューが表示されるか
       assertThat(result, is("prototypes/search"));

--- a/src/test/java/in/tech_camp/protospace_b/controller/UserControllerUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_b/controller/UserControllerUnitTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
@@ -35,6 +36,9 @@ public class UserControllerUnitTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private Authentication authentication;
 
     @InjectMocks
     private UserController userController;
@@ -155,7 +159,7 @@ public class UserControllerUnitTest {
       //model定義
       Model model = new ExtendedModelMap();
       //Controller実行とresultにその結果を入れる
-      String result = userController.showUserDetail(mockUser.getId(), model);
+      String result = userController.showUserDetail(mockUser.getId(), model, authentication);
       // 結果View画面が詳細ページなのか確認
       assertThat(result, is("users/show"));
       // ページにmodelがちゃんと渡されてるか確認

--- a/src/test/java/in/tech_camp/protospace_b/service/LikeServiceUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_b/service/LikeServiceUnitTest.java
@@ -1,0 +1,60 @@
+package in.tech_camp.protospace_b.service;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import in.tech_camp.protospace_b.repository.LikeRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class LikeServiceUnitTest {
+
+  @Mock
+  private LikeRepository likeRepository;
+
+  @InjectMocks
+  private LikeService likeService;
+
+  @Nested
+  class 未いいねの場合 {
+
+    @Test
+    public void いいねが保存されisLikedがtrueで返ること() {
+      Integer userId = 1;
+      Integer prototypeId = 100;
+      when(likeRepository.countByUserAndPrototype(userId, prototypeId)).thenReturn(0);
+      when(likeRepository.countByPrototypeId(prototypeId)).thenReturn(1);
+
+      Map<String, Object> result = likeService.toggleLike(userId, prototypeId);
+
+      verify(likeRepository, times(1)).insert(userId, prototypeId);
+      assertEquals(true, result.get("isLiked"));
+    }
+  }
+
+  @Nested
+  class いいね済みの場合 {
+
+    @Test
+    public void いいねが削除されisLikedがfalseで返ること() {
+      Integer userId = 1;
+      Integer prototypeId = 100;
+      when(likeRepository.countByUserAndPrototype(userId, prototypeId)).thenReturn(1);
+      when(likeRepository.countByPrototypeId(prototypeId)).thenReturn(0);
+
+      Map<String, Object> result = likeService.toggleLike(userId, prototypeId);
+
+      verify(likeRepository, times(1)).delete(userId, prototypeId);
+      assertEquals(false, result.get("isLiked"));
+    }
+  }
+}


### PR DESCRIPTION
### 実装内容
- 以下ページのプロトタイプにいいね機能（非同期）を追加
  - トップページ（プロトタイプ一覧）
  - 検索結果ページ
  - ユーザー詳細ページ
  - プロトタイプ詳細ページ

- いいねはlikesテーブル（中間テーブル）を追加。
  - user_idとprototype_idを外部キーに持つ
  - user_idとprototype_idは複合ユニークなため、同じ投稿に2度いいねは出来ない
  - ユーザーが削除、またはプロトタイプが削除されたら紐づくいいねも一緒に削除される
 - いいねボタンは、以下の挙動
   - 未いいねの状態で押下するとハートが赤くなりカウントが1増える（保存される）
   - いいね済みの状態で押下するとハートが白く戻りカウントが1減る（削除される）
  
- 非同期処理にするため、JSでfetch関数を使用。likeControllerはJSONを返す@RestControllerで実装

- 上記に合わせてテスト追加と修正
※いいね表示を追加した画面のcontrollerテストについては、プロトタイプ一覧のみ実装しています