### PR TITLE
バグ修正/prototype-index-card_wrapperのＣＳＳ修正

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -185,7 +185,6 @@ main {
   justify-content: flex-start;
   gap: 25px;
   align-items: center;
-  min-height: calc(100vh - 161px);
 }
 .prototype-index-card {
   width: calc((100% - 50px) / 3);


### PR DESCRIPTION
# prototype-index-card_wrapperのＣＳＳ修正
- 拡大するときcardが下に下がるバグ
-  min-height: calc(100vh - 161px);設定を削除