### PR TITLE
追加実装/いいね未ログイン時のモーダル作成

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -264,18 +264,23 @@ main {
 }
 
 .modal-content {
+  position: relative;
   background-color: white;
-  padding: 30px;
+  padding: 40px 20px 30px;
+  background-color: white;
   border-radius: 12px;
   text-align: center;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
   max-width: 500px;
+  min-height: 250px;
   width: 90%;
+  align-items: center;
 }
 
 .modal-content h3 {
   color: #333;
   margin-bottom: 15px;
+  margin-top: 15px;
 }
 
 .modal-content p {
@@ -287,24 +292,52 @@ main {
 .modal-footer {
   display: flex;
   justify-content: center;
-  gap: 20px;
+  gap: 25px;
 }
 
 .modal-close-btn {
-  background-color: #333;
-  color: white;
-  border: none;
-  min-width: 140px;
-  width: auto;
-  padding: 10px 20px;
-  border-radius: 6px;
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 20px;
+  font-weight: bold;
+  color: black;
   cursor: pointer;
-  font-size: 1rem;
-  transition: background-color 0.2s;
+  line-height: 1;
+  padding: 5px;
 }
 
 .modal-close-btn:hover {
-  background-color: #555;
+  background-color: #efefef;
+  border-radius: 50%;
+}
+
+/* モーダルの削除実行ボタン */
+.modal-delete-execute-btn {
+  padding: 0.7em 3em;
+  background-color: #ff4d4f;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: opacity 0.2s;
+}
+
+.modal-delete-execute-btn:hover {
+  opacity: 0.8;
+}
+
+/* モーダル内トップページへ戻るボタン */
+.modal-toppage-btn {
+  padding: 0.7em 3em;
+  background-color: #87cefa;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: opacity 0.2s;
 }
 
 /* 1024px以下の表示 */
@@ -795,4 +828,32 @@ footer {
     padding: 12px 8px;
     font-size: 0.9rem;
   }
+}
+
+/* ==========================================
+  未ログイン時のモーダル
+   ========================================== */
+.modal-buttons {
+  display: flex;
+  gap: 25px;
+  justify-content: center;
+}
+
+.modal-register-btn,
+.modal-login-btn {
+  display: inline-block;
+  padding: 0.5em 1.9em;
+  font-size: 1em;
+  color: #87cefa;
+  text-decoration: none;
+  user-select: none;
+  border: 1px #87cefa solid;
+  border-radius: 3px;
+  transition: 0.4s ease;
+}
+
+.modal-register-btn:hover,
+.modal-login-btn:hover {
+  color: #fff;
+  background: #87cefa;
 }

--- a/src/main/resources/static/js/like.js
+++ b/src/main/resources/static/js/like.js
@@ -1,42 +1,74 @@
 document.addEventListener("DOMContentLoaded", () => {
-  
-    document.addEventListener("click", async (event) => {
-      const button = event.target.closest(".like-btn");
+  const modal = document.getElementById("login-modal-for-like");
+  const closeBtn = document.getElementById("close-login-modal");
 
-      if (!button) return;
+  document.addEventListener("click", async (event) => {
+    const button = event.target.closest(".like-btn");
 
-      const prototypeId = button.getAttribute("data-prototype-id");
-      const icon = button.querySelector(".like-icon");
-      const countSpan = button.querySelector(".like-count");
+    if (!button) return;
 
-      try {
-        const response = await fetch(`/api/prototypes/${prototypeId}/like`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        });
+    const prototypeId = button.getAttribute("data-prototype-id");
 
-        if (!response.ok) {
-          throw new Error("いいねの処理に失敗しました");
-        }
+    // 未ログイン時
+    if (!prototypeId) {
+      event.preventDefault();
 
-        const data = await response.json();
+      // クリックされた瞬間に改めてモーダルをHTMLから探す
+      const modal = document.getElementById("login-modal-for-like");
 
-        // 表示の更新
-        countSpan.innerText = data.LikeCount;
+      if (modal) {
+        modal.style.display = "flex";
 
-        if (data.isLiked) {
-          icon.style.fontVariationSettings = "'FILL' 1";
-          icon.style.color = "#e0245e";
-        } else {
-          icon.style.fontVariationSettings = "'FILL' 0";
-          icon.style.color = "#657786";
-        }
-      } catch (error) {
-        console.error("Error:", error);
-        alert("エラーが発生しました。ログイン状態を確認してください。");
+        // モーダル内の「✖」ボタンで閉じる処理
+        const closeBtn = modal.querySelector("#modal-close-btn");
+        closeBtn.onclick = () => {
+          modal.style.display = "none";
+        };
+
+        // 背景クリックで閉じる処理
+        modal.onclick = (event) => {
+          if (event.target === modal) modal.style.display = "none";
+        };
+      } else {
+        console.error(
+          "モーダルが見つかりません。HTMLのth:replaceを確認してください。",
+        );
       }
-    });
-  });
+      return;
+    }
+    // ログイン時の処理：fetchを実行
+    event.preventDefault();
 
+    const icon = button.querySelector(".like-icon");
+    const countSpan = button.querySelector(".like-count");
+
+    try {
+      const response = await fetch(`/api/prototypes/${prototypeId}/like`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("いいねの処理に失敗しました");
+      }
+
+      const data = await response.json();
+
+      // 表示の更新
+      countSpan.innerText = data.LikeCount;
+
+      if (data.isLiked) {
+        icon.style.fontVariationSettings = "'FILL' 1";
+        icon.style.color = "#e0245e";
+      } else {
+        icon.style.fontVariationSettings = "'FILL' 0";
+        icon.style.color = "#657786";
+      }
+    } catch (error) {
+      console.error("Error:", error);
+      alert("エラーが発生しました。ログイン状態を確認してください。");
+    }
+  });
+});

--- a/src/main/resources/templates/common/like.html
+++ b/src/main/resources/templates/common/like.html
@@ -36,18 +36,18 @@
       </div>
 
       <div
-        class="like-container"
+        class="like-container like-btn"
         th:unless="${#authorization.expression('isAuthenticated()')}"
-        style="display: flex; align-items: center"
+        style="display: flex; align-items: center; cursor: pointer"
       >
         <span
           class="material-symbols-outlined like-icon"
-          th:data-is-liked="${prototype.isLiked}"
           th:style="${prototype.isLiked == true} ? 'font-variation-settings: \'FILL\' 1; color: #e0245e; font-size: 20px;' : 'font-variation-settings: \'FILL\' 0; color: #657786; font-size: 20px;'"
         >
-          favorite</span
-        >
+          favorite
+        </span>
         <span
+          class="like-count"
           style="margin-left: 4px; color: #657786; font-size: 14px"
           th:text="${prototype.likeCount}"
           >0</span

--- a/src/main/resources/templates/common/login_modal_for_like.html
+++ b/src/main/resources/templates/common/login_modal_for_like.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <body>
+    <div
+      th:fragment="login_modal_for_like"
+      id="login-modal-for-like"
+      class="modal-overlay"
+      style="display: none"
+    >
+      <div class="modal-content">
+        <span id="modal-close-btn" class="modal-close-btn">&times;</span>
+        <h3>いいねするには会員登録またはログインが必要です</h3>
+        <p>プロトタイプに共感したら、ログインして応援しましょう！</p>
+        <div class="modal-buttons">
+          <a th:href="@{/users/register}" class="modal-register-btn"
+            >新規登録</a
+          >
+          <a th:href="@{/users/login}" class="modal-login-btn">ログイン</a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -24,27 +24,52 @@
         </div>
 
         <div id="search-results">
-          <h3 class="prototype-keyword" th:if="${keyword != null && !keyword.isEmpty()}" th:text="|検索結果:${keyword}|"></h3>
-          <div class="prototype-index-card_wrapper" >
-            <div class="prototype-index-card" th:each="prototype : ${prototypes}">
-              <a th:href="@{/prototypes/{id}(id=${prototype.id})}" id="prototype_link">
-                <img class="prototype-index-card_img"  th:src="@{${prototype.image}}">
+          <h3
+            class="prototype-keyword"
+            th:if="${keyword != null && !keyword.isEmpty()}"
+            th:text="|検索結果:${keyword}|"
+          ></h3>
+          <div class="prototype-index-card_wrapper">
+            <div
+              class="prototype-index-card"
+              th:each="prototype : ${prototypes}"
+            >
+              <a
+                th:href="@{/prototypes/{id}(id=${prototype.id})}"
+                id="prototype_link"
+              >
+                <img
+                  class="prototype-index-card_img"
+                  th:src="@{${prototype.image}}"
+                />
               </a>
               <div class="prototype-index-card_body">
-                <a class="prototype-index-card_title" th:href="@{/prototypes/{id}(id=${prototype.id})}" th:text="${prototype.name}"></a>
-                <p class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></p>
+                <a
+                  class="prototype-index-card_title"
+                  th:href="@{/prototypes/{id}(id=${prototype.id})}"
+                  th:text="${prototype.name}"
+                ></a>
+                <p
+                  class="prototype-index-card_summary"
+                  th:text="${prototype.catchCopy}"
+                ></p>
                 <div class="prototype-index-user-and-like">
                   <div th:replace="~{common/like :: like}"></div>
-                  <a class="prototype-index-card_user" th:href="@{/users/{id}(id=${prototype.user.id})}" th:text="'by ' + ${prototype.user.name}"></a>
+                  <a
+                    class="prototype-index-card_user"
+                    th:href="@{/users/{id}(id=${prototype.user.id})}"
+                    th:text="'by ' + ${prototype.user.name}"
+                  ></a>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
+      <div
+        th:replace="~{common/login_modal_for_like :: login_modal_for_like}"
+      ></div>
     </main>
-
     <footer th:replace="~{common/footer :: footer}"></footer>
-    
   </body>
 </html>

--- a/src/main/resources/templates/prototypes/show.html
+++ b/src/main/resources/templates/prototypes/show.html
@@ -69,7 +69,12 @@
         <div class="prototype-show-comment-section">
           <div th:if="${#authorization.expression('isAuthenticated()')}">
             <div id="error-container">
-              <div th:if="${errorMessages}" th:each="error : ${errorMessages}" class="new-error" id="new-error">
+              <div
+                th:if="${errorMessages}"
+                th:each="error : ${errorMessages}"
+                class="new-error"
+                id="new-error"
+              >
                 <span th:text="${error.defaultMessage}"></span>
               </div>
             </div>
@@ -115,7 +120,9 @@
         </div>
       </div>
     </div>
-
+    <div
+      th:replace="~{common/login_modal_for_like :: login_modal_for_like}"
+    ></div>
     <footer th:replace="~{common/footer :: footer}"></footer>
     <script th:src="@{/js/comment.js}"></script>
   </body>

--- a/src/main/resources/templates/users/show.html
+++ b/src/main/resources/templates/users/show.html
@@ -14,16 +14,20 @@
         onclick="closeOnOverlayClick(event, 'confirmModal')"
       >
         <div class="modal-content" onclick="event.stopPropagation()">
+          <span class="modal-close-btn" onclick="closeModal('confirmModal')"
+            >&times;</span
+          >
           <h3>本当にアカウントを削除しますか？</h3>
           <p>
             これまでに投稿したプロトタイプやコメントなどの<br />
             <strong>データはすべて削除され復元できません。</strong>
           </p>
           <div class="modal-footer">
-            <button type="button" onclick="closeModal('confirmModal')" class="modal-close-btn">
-              戻る
-            </button>
-            <button type="button" th:onclick="|executeDelete(${user.id})|" class="modal-close-btn">
+            <button
+              type="button"
+              th:onclick="|executeDelete(${user.id})|"
+              class="modal-delete-execute-btn"
+            >
               削除する
             </button>
           </div>
@@ -37,7 +41,7 @@
             ご利用ありがとうございました。<br />
             アカウント削除が無事に行われました。
           </p>
-          <button type="button" onclick="goToIndex()" class="modal-close-btn">
+          <button type="button" onclick="goToIndex()" class="modal-toppage-btn">
             トップページへ
           </button>
         </div>
@@ -45,16 +49,24 @@
 
       <section class="user-show-info">
         <div class="user-show-info-head">
-          <h2 class="user-show-h2" th:text="${user.name} + 'さんの情報'">名前さんの情報</h2>
+          <h2 class="user-show-h2" th:text="${user.name} + 'さんの情報'">
+            名前さんの情報
+          </h2>
           <div
             class="user-show-button-section"
             th:if="${#authorization.expression('isAuthenticated()') and #authentication.principal.getId == user.id}"
           >
             <div class="prototype-show-button-section">
-              <a th:href="@{/users/{id}/edit(id=${user.id})}" class="prototype-show-btn"
+              <a
+                th:href="@{/users/{id}/edit(id=${user.id})}"
+                class="prototype-show-btn"
                 >編集する</a
               >
-              <button type="button" class="prototype-show-btn" onclick="openWithdrawModal()">
+              <button
+                type="button"
+                class="prototype-show-btn"
+                onclick="openWithdrawModal()"
+              >
                 アカウント削除
               </button>
             </div>
@@ -86,7 +98,10 @@
       </section>
 
       <section class="user-show-prototype-section">
-        <h2 class="user-show-prototype-name" th:text="${user.name} + 'さんのプロトタイプ'">
+        <h2
+          class="user-show-prototype-name"
+          th:text="${user.name} + 'さんのプロトタイプ'"
+        >
           名前さんのプロトタイプ
         </h2>
         <!-- ユーザー個人のPrototype一覧 -->
@@ -96,14 +111,23 @@
             <a
               id="prototype_link"
               th:href="@{/prototypes/{prototypeId}(prototypeId=${prototype.id})}"
-              ><img class="prototype-index-card_img" th:src="@{${prototype.image}}" alt="img"
+              ><img
+                class="prototype-index-card_img"
+                th:src="@{${prototype.image}}"
+                alt="img"
             /></a>
 
             <div class="prototype-index-card_body">
-              <h3 th:text="${prototype.name}" class="prototype-index-card_title">
+              <h3
+                th:text="${prototype.name}"
+                class="prototype-index-card_title"
+              >
                 プロトタイプタイトル
               </h3>
-              <p class="prototype-index-card_summary" th:text="${prototype.catchCopy}"></p>
+              <p
+                class="prototype-index-card_summary"
+                th:text="${prototype.catchCopy}"
+              ></p>
               <div class="prototype-index-user-and-like">
                 <div th:replace="~{common/like :: like}"></div>
 
@@ -118,6 +142,9 @@
           </div>
         </div>
       </section>
+      <div
+        th:replace="~{common/login_modal_for_like :: login_modal_for_like}"
+      ></div>
     </main>
     <footer th:replace="~{common/footer :: footer}"></footer>
   </body>


### PR DESCRIPTION
### 実装内容
- 未ログイン時にいいねボタンを押下するとモーダルが出現し、ログインか新規登録画面に遷移できるようにモーダル作成
- モーダルは右上の✖を押下または背景のグレーを押下で消滅
- 「新規登録」を押せば新規登録画面へ、「ログイン」を押せばログイン画面へ遷移
- 未ログイン時のいいねはボタンではなくspanタグにしているので、カーソルを合わせたらポインターが出るように修正
- いいね設置画面すべてでモーダル出現設定
  - トップページ（検索後の画面も）
  - ユーザー詳細ページ
  - プロトタイプ詳細ページ
 

<img width="943" height="672" alt="スクリーンショット 2026-01-23 095943" src="https://github.com/user-attachments/assets/e73b0346-9b87-41c6-b092-2612c2e1fe54" />


#### 補足
- ユーザー削除時のモーダルとstyleを合わせるためクラス名ちょっと統一してます
- ユーザー削除モーダルの「戻る」ボタンを廃止し、いいねと同じく右上に✖ボタンを設置

<img width="951" height="666" alt="スクリーンショット 2026-01-23 095908" src="https://github.com/user-attachments/assets/9285120c-5d90-4a1f-ba63-48af04f8cb62" />

<img width="955" height="667" alt="スクリーンショット 2026-01-23 101405" src="https://github.com/user-attachments/assets/ed4bc088-0447-4c89-b862-803e4d30926e" />
