### PR TITLE
追加実装(予備)/新規登録後ログイン状態でトップページに遷移する

### DIFF
--- a/src/main/java/in/tech_camp/protospace_b/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_b/controller/UserController.java
@@ -6,7 +6,10 @@ import java.util.stream.Collectors;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -57,7 +60,8 @@ public class UserController {
       ValidationOrder.PositionSequence.class
   }) UserForm userForm,
       BindingResult result,
-      Model model) {
+      Model model,
+      HttpServletRequest request) {
     userForm.validatePasswordConfirmation(result);
     if (userRepository.existsByEmail(userForm.getEmail())) {
       result.rejectValue("email", "null", "メールアドレスは既に存在します");
@@ -83,13 +87,24 @@ public class UserController {
 
     try {
       userService.createUserWithEncryptedPassword(userEntity);
+      // 自動ログイン処理
+      CustomUserDetails userDetails = new CustomUserDetails(userEntity);
+      UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+        userDetails, null, userDetails.getAuthorities());
+
+      SecurityContext context = SecurityContextHolder.createEmptyContext();
+      context.setAuthentication(token);
+      SecurityContextHolder.setContext(context);
+
+      HttpSession session = request.getSession(true);
+      session.setAttribute("SPRING_SECURITY_CONTEXT", context);
     } catch (Exception e) {
       System.out.println("エラー：" + e);
       return "redirect:users/register";
     }
 
-    // 新規登録成功時、ログイン画面に遷移
-    return "redirect:users/login";
+    // 新規登録成功時、トップページに遷移
+    return "redirect:/";
   }
 
   // 途中でログイン

--- a/src/test/java/in/tech_camp/protospace_b/controller/UserControllerUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_b/controller/UserControllerUnitTest.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.anyInt;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import static org.mockito.Mockito.doThrow;
@@ -35,8 +35,8 @@ import in.tech_camp.protospace_b.form.UserForm;
 import in.tech_camp.protospace_b.repository.UserRepository;
 import in.tech_camp.protospace_b.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
@@ -78,8 +78,6 @@ public class UserControllerUnitTest {
   public void setUp() {
     mockUser = UserFactory.createMockUser();
   }
-
-  // 新規登録
 
   @Nested
   class ログインセッション {
@@ -131,7 +129,7 @@ public class UserControllerUnitTest {
       when(bindingResult.hasErrors()).thenReturn(true);
 
       // 2. 実行：正しい引数で呼び出す
-      String result = userController.createUser(userForm, bindingResult, model);
+      String result = userController.createUser(userForm, bindingResult, model, request);
 
       // 3. 検証
       assertThat(result, is("users/register"));
@@ -154,7 +152,7 @@ public class UserControllerUnitTest {
 
       // 実行
       Model model = new ExtendedModelMap();
-      String result = userController.createUser(form, bindingResult, model);
+      String result = userController.createUser(form, bindingResult, model, request);
 
       // 検証: 返り値がリダイレクト先と一致するか
       assertThat(result, is("redirect:users/register"));
@@ -179,11 +177,37 @@ public class UserControllerUnitTest {
       Model model = new ExtendedModelMap();
 
       // 3. 実行
-      String viewName = userController.createUser(userForm, bindingResult, model);
+      String viewName = userController.createUser(userForm, bindingResult, model, request);
 
       // 4. 検証
       assertThat(viewName, is("users/register"));
       verify(bindingResult).rejectValue("email", "null", "メールアドレスは既に存在します");
+    }
+    @Test
+    public void ユーザー登録が成功した場合は自動ログインされトップページにリダイレクトされる() {
+      UserForm userForm = new UserForm();
+      userForm.setName("テスト太郎");
+      userForm.setEmail("test@example.com");
+      userForm.setPassword("password123");
+      userForm.setPasswordConfirmation("password123");
+
+      when(bindingResult.hasErrors()).thenReturn(false);
+      when(userRepository.existsByEmail(anyString())).thenReturn(false);
+      
+      // 自動ログイン処理に必要なHttpServletRequestからHttpSessionを取得する動きをモック化
+      when(request.getSession(true)).thenReturn(session);
+
+      Model model = new ExtendedModelMap();
+
+      String result = userController.createUser(userForm, bindingResult, model, request);
+
+      assertThat(result, is("redirect:/"));
+      
+      // ユーザー保存メソッドが呼ばれたか
+      verify(userService, times(1)).createUserWithEncryptedPassword(any(UserEntity.class));
+      
+      // セッションに認証情報（SPRING_SECURITY_CONTEXT）がセットされたか検証
+      verify(session, times(1)).setAttribute(eq("SPRING_SECURITY_CONTEXT"), any());
     }
   }
 


### PR DESCRIPTION
#### 実装内容
- 新規登録すると認証トークンを作成する
- そのトークン情報をspring securityに渡してログイン状態を保持する
- 新規登録成功後はログインした状態でトップページに遷移する
- 合わせてcontrollerテストに新規登録成功後のテストケースを追加

- #83 